### PR TITLE
Run without upstart

### DIFF
--- a/lib/procfile_upstart_exporter/destroyer.rb
+++ b/lib/procfile_upstart_exporter/destroyer.rb
@@ -21,7 +21,11 @@ class ProcfileUpstartExporter::Destroyer
   attr_accessor :procfile_parser
 
   def destroy_all_jobs application, path
-    stopping_output = IO.popen(['stop', application], err: [:child, :out]).read
+    stopping_output = begin
+      IO.popen(['stop', application], err: [:child, :out]).read
+    rescue Errno::ENOENT
+      "Upstart binary not found. #{application} not stopped."
+    end
     ProcfileUpstartExporter.logger.debug stopping_output
     FileUtils.rm_rf File.join(path, "#{ application }.conf")
     FileUtils.rm_rf File.join(path, application)

--- a/lib/procfile_upstart_exporter/destroyer.rb
+++ b/lib/procfile_upstart_exporter/destroyer.rb
@@ -32,7 +32,11 @@ class ProcfileUpstartExporter::Destroyer
       process_name = File.basename job_absolute_path, '.conf'
       unless processes_names.include? process_name
         job = File.join application, process_name
-        stopping_output = IO.popen(['stop', job], err: [:child, :out]).read
+        stopping_output = begin
+          IO.popen(['stop', job], err: [:child, :out]).read
+        rescue Errno::ENOENT
+          "Upstart binary not found. #{job} not stopped."
+        end
         ProcfileUpstartExporter.logger.debug stopping_output
         FileUtils.rm_rf File.join(path, "#{ job }.conf")
       end


### PR DESCRIPTION
If I'm testing this gem on OSX without the upstart binaries present, it fails on the destroy step. This pull request wraps the call to the `stop` program, and catches file-not-found errors.
