### PR TITLE
Ignore empty lines in the Procfile.

### DIFF
--- a/lib/procfile_upstart_exporter/procfile_parser.rb
+++ b/lib/procfile_upstart_exporter/procfile_parser.rb
@@ -3,7 +3,8 @@ class ProcfileUpstartExporter::ProcfileParser
     ProcfileUpstartExporter.logger.debug 'Start parsing Procfile ' \
                                          "`#{ procfile }'"
     if File.exists? procfile
-      File.read(procfile).split("\n").map(&:strip).reject(&:empty?).map do |process_line|
+      processes = File.read(procfile).split("\n").map(&:strip).reject(&:empty?)
+      processes.map do |process_line|
         ProcfileUpstartExporter::Process.new(
           *process_line.scan(/\A([^:]+):(.*)\z/).first.map(&:strip)
         )

--- a/lib/procfile_upstart_exporter/procfile_parser.rb
+++ b/lib/procfile_upstart_exporter/procfile_parser.rb
@@ -3,7 +3,7 @@ class ProcfileUpstartExporter::ProcfileParser
     ProcfileUpstartExporter.logger.debug 'Start parsing Procfile ' \
                                          "`#{ procfile }'"
     if File.exists? procfile
-      File.read(procfile).split("\n").map do |process_line|
+      File.read(procfile).split("\n").map(&:strip).reject(&:empty?).map do |process_line|
         ProcfileUpstartExporter::Process.new(
           *process_line.scan(/\A([^:]+):(.*)\z/).first.map(&:strip)
         )


### PR DESCRIPTION
This pull request keeps the parser from raising an exception when it encounters a blank line.
