### PR TITLE
Add group option to allow non-user groups.

### DIFF
--- a/lib/procfile_upstart_exporter/cli.rb
+++ b/lib/procfile_upstart_exporter/cli.rb
@@ -16,6 +16,7 @@ class ProcfileUpstartExporter::Cli < Thor
   option :log, default: '/var/log'
   option :environment, default: '.env'
   option :user, default: 'app'
+  option :group, default: false, desc: "Sets the group that the process runs with. Specify --no-group to not specify a group. Defaults to the same as --user."
   option :path, default: '/etc/init'
   def create
     enter_verbose_mode if options[:verbose]
@@ -25,6 +26,7 @@ class ProcfileUpstartExporter::Cli < Thor
                    options[:log],
                    options[:environment],
                    options[:user],
+                   options[:group],
                    options[:path]
   end
 

--- a/lib/procfile_upstart_exporter/process_job_renderer.rb
+++ b/lib/procfile_upstart_exporter/process_job_renderer.rb
@@ -11,7 +11,7 @@ class ProcfileUpstartExporter::ProcessJobRenderer
     @erb = ERB.new template, nil, '-'
   end
 
-  def render application, user, environment_variables, application_root,
+  def render application, user, group, environment_variables, application_root,
              log, process
     ProcfileUpstartExporter.logger.debug 'Start rendering process job'
     # Double assign to avoid warnings

--- a/spec/procfile_upstart_exporter/creator_spec.rb
+++ b/spec/procfile_upstart_exporter/creator_spec.rb
@@ -13,7 +13,7 @@ describe ProcfileUpstartExporter::Creator do
   describe '#create' do
     subject(:create) {
       Dir.chdir 'spec/fixtures/sample-application' do
-        creator.create application, procfile, log, environment, user,
+        creator.create application, procfile, log, environment, user, group,
                                                               upstart_jobs_path
       end
     }
@@ -24,6 +24,7 @@ describe ProcfileUpstartExporter::Creator do
     let(:application_log)   { "#{ log }/#{ application}" }
     let(:environment)       { 'environment'              }
     let(:user)              { 'bin'                      }
+    let(:group)             { 'bin'                      }
     let(:upstart_jobs_path) { temp_dir                   }
     let(:application_root)  {
       File.expand_path 'spec/fixtures/sample-application'
@@ -52,7 +53,7 @@ describe ProcfileUpstartExporter::Creator do
                                    .and_return environment_variables
 
       allow(process_job_renderer).to receive(:render)
-        .with(application, user, environment_variables, application_root,
+        .with(application, user, group, environment_variables, application_root,
               log, web_process)
         .and_return <<-JOB_CONFIGURATION
 env RAILS_ENV=production
@@ -61,7 +62,7 @@ exec bundle exec rails server -p 5000
 JOB_CONFIGURATION
 
       allow(process_job_renderer).to receive(:render)
-        .with(application, user, environment_variables, application_root,
+        .with(application, user, group, environment_variables, application_root,
               log, background_process)
         .and_return <<-JOB_CONFIGURATION
 env RAILS_ENV=production

--- a/spec/procfile_upstart_exporter/process_job_renderer_spec.rb
+++ b/spec/procfile_upstart_exporter/process_job_renderer_spec.rb
@@ -7,12 +7,13 @@ describe ProcfileUpstartExporter::ProcessJobRenderer do
 
   describe '#render' do
     subject(:process_job) {
-      process_job_renderer.render application, user, environment_variables,
+      process_job_renderer.render application, user, group, environment_variables,
                                   application_root, log, process
     }
 
     let(:application)       { 'application'                      }
     let(:user)              { 'bin'                              }
+    let(:group)             { 'bin'                              }
     let(:log)               { "#{ temp_dir }/log"                }
     let(:application_root)  {
       File.expand_path 'spec/fixtures/sample-application'

--- a/spec/procfile_upstart_exporter/process_job_renderer_spec.rb
+++ b/spec/procfile_upstart_exporter/process_job_renderer_spec.rb
@@ -49,5 +49,55 @@ chdir #{ application_root }
 exec bash -lc 'bundle exec rails server -p 5000 >> #{ log }/application/web.log 2>&1'
 PROCESS_JOB
     end
-  end
+
+    context 'with a nil group' do
+      let(:group) { nil }
+
+      it 'renders the template without setgid' do
+        expect(process_job).to eq(<<-PROCESS_JOB)
+start on starting application
+stop  on stopping application
+
+respawn
+
+setuid bin
+
+umask 0002
+
+env HOME=/bin
+env RAILS_ENV=production
+env DATABASE_URL=postgresl://localhost:4567
+
+chdir #{ application_root }
+
+exec bash -lc 'bundle exec rails server -p 5000 >> #{ log }/application/web.log 2>&1'
+PROCESS_JOB
+      end
+    end
+
+    context 'with a group of foo' do
+      let(:group) { 'foo' }
+
+      it 'renders the template without setgid' do
+        expect(process_job).to eq(<<-PROCESS_JOB)
+start on starting application
+stop  on stopping application
+
+respawn
+
+setuid bin
+setgid foo
+
+umask 0002
+
+env HOME=/Users/bin
+env RAILS_ENV=production
+env DATABASE_URL=postgresl://localhost:4567
+
+chdir #{ application_root }
+
+exec bash -lc 'bundle exec rails server -p 5000 >> #{ log }/application/web.log 2>&1'
+PROCESS_JOB
+      end
+    end  end
 end

--- a/spec/procfile_upstart_exporter/process_job_renderer_spec.rb
+++ b/spec/procfile_upstart_exporter/process_job_renderer_spec.rb
@@ -90,7 +90,7 @@ setgid foo
 
 umask 0002
 
-env HOME=/Users/bin
+env HOME=/bin
 env RAILS_ENV=production
 env DATABASE_URL=postgresl://localhost:4567
 

--- a/templates/process.conf.erb
+++ b/templates/process.conf.erb
@@ -4,7 +4,9 @@ stop  on stopping <%= application %>
 respawn
 
 setuid <%= user %>
-setgid <%= user %>
+<% if group %>
+  setgid <%= group %>
+<% end %>
 
 umask 0002
 

--- a/templates/process.conf.erb
+++ b/templates/process.conf.erb
@@ -4,9 +4,9 @@ stop  on stopping <%= application %>
 respawn
 
 setuid <%= user %>
-<% if group %>
-  setgid <%= group %>
-<% end %>
+<% if group -%>
+setgid <%= group %>
+<% end -%>
 
 umask 0002
 


### PR DESCRIPTION
Some user accounts don't have a group by the same name associated with them. This test allows you to set a different group id, or none at all to retain the original group id.
